### PR TITLE
fixed #defines

### DIFF
--- a/src/ofxBox2dPolygonUtils.h
+++ b/src/ofxBox2dPolygonUtils.h
@@ -506,3 +506,8 @@ static vector<hPoint> calcConvexHull(vector<hPoint> P) {
 	H.resize(k);
 	return H;
 }
+
+#undef norm2
+#undef norm
+#undef d2
+#undef d


### PR DESCRIPTION
if including box2d with opencv2, the #define for norm conflicts with some of the headers. Undefining it clears up the issue
