### PR TITLE
MSVC build issue

### DIFF
--- a/libs/triangle/triangle_impl.hpp
+++ b/libs/triangle/triangle_impl.hpp
@@ -232,7 +232,7 @@
 /* If yours is not a Unix system, define the NO_TIMER compiler switch to     */
 /*   remove the Unix-specific timing code.                                   */
 
-#ifdef TARGET_WIN32
+#ifdef _WIN32 
 	#define NO_TIMER
 #endif
 

--- a/src/ofxBox2dBaseShape.h
+++ b/src/ofxBox2dBaseShape.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ofMain.h"
-#include "Box2D.h"
+#include "Box2d/Box2D.h"
 #include "ofxBox2dUtils.h"
 
 class ofxBox2dBaseShape {

--- a/src/ofxBox2dContactListener.h
+++ b/src/ofxBox2dContactListener.h
@@ -1,7 +1,7 @@
 
 #pragma once
 #include "ofMain.h"
-#include "Box2D.h"
+#include "Box2D/Box2D.h"
 
 /*
 

--- a/src/ofxBox2dJoint.h
+++ b/src/ofxBox2dJoint.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ofMain.h"
-#include "Box2D.h"
+#include "Box2D/Box2D.h"
 #include "ofxBox2dUtils.h"
 
 #define BOX2D_DEFAULT_FREQ      4.0

--- a/src/ofxBox2dPolygonUtils.h
+++ b/src/ofxBox2dPolygonUtils.h
@@ -9,7 +9,7 @@
 
 #pragma once
 #include "ofMain.h"
-#include "del_interface.hpp"
+#include "triangle/del_interface.hpp"
 #include <algorithm>
 
 using namespace tpp;

--- a/src/ofxBox2dRender.h
+++ b/src/ofxBox2dRender.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ofMain.h"
-#include "Box2D.h"
+#include "Box2D/Box2D.h"
 
 class ofxBox2dRender : public b2Draw {
 	

--- a/src/ofxBox2dUtils.h
+++ b/src/ofxBox2dUtils.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "ofMain.h"
-#include "Box2D.h"
+#include "Box2d/Box2D.h"
 
 
 #define OFX_BOX2D_SCALE 30.0f


### PR DESCRIPTION
Fixed preprocessor statement for MSVC builds. Use of TARGET_WIN32 breaks MSVC builds. Fixes #49.