### PR TITLE
Fixing several minor issues

### DIFF
--- a/src/ofxBox2dBaseShape.cpp
+++ b/src/ofxBox2dBaseShape.cpp
@@ -24,8 +24,10 @@ ofxBox2dBaseShape::ofxBox2dBaseShape() {
 
 //----------------------------------------
 ofxBox2dBaseShape::~ofxBox2dBaseShape() {
-    ofLog(OF_LOG_VERBOSE, "~ofxBox2dBaseShape(%p)\n", body);
-    destroy();
+	ofLog(OF_LOG_VERBOSE, "~ofxBox2dBaseShape(%p)\n", body);
+	if (isBody()) {
+		destroy();
+	}
 }
 
 //------------------------------------------------
@@ -56,8 +58,6 @@ bool ofxBox2dBaseShape::shouldRemoveOffScreen(ofPtr<ofxBox2dBaseShape> shape) {
 //----------------------------------------
 bool ofxBox2dBaseShape::isBody() {
 	if (body == NULL) {
-		//cout << __FILE__ << __func__ << endl;
-		ofLog(OF_LOG_ERROR, "ofxBox2dBaseShape:: - body is not defined -");
 		return false;
 	}
 	return true;
@@ -130,6 +130,7 @@ void* ofxBox2dBaseShape::setData(void*data) {
 	else {
 		ofLog(OF_LOG_NOTICE, "ofxBox2dBaseShape:: - must have a valid body -");
 	}
+	return NULL;
 }
 
 //------------------------------------------------ 

--- a/src/ofxBox2dPolygon.cpp
+++ b/src/ofxBox2dPolygon.cpp
@@ -25,8 +25,8 @@ ofxBox2dPolygon::~ofxBox2dPolygon() {
 //----------------------------------------
 void ofxBox2dPolygon::clear() {
 	ofxBox2dBaseShape::destroy();
-    ofxBox2dPolygon::clear();
-    mesh.clear();
+	ofPolyline::clear();
+	mesh.clear();
 }
 
 //----------------------------------------
@@ -124,7 +124,7 @@ void ofxBox2dPolygon::makeConvexPoly() {
 //----------------------------------------
 void ofxBox2dPolygon::create(b2World * b2dworld) {
 
-	if(size() <= 3) {
+	if(size() < 3) {
 		ofLog(OF_LOG_NOTICE, "need at least 3 points: %i\n", (int)size());
 		return;	
 	}


### PR DESCRIPTION
Okay, I decided to make a branch off your master, and send along these four minor (but important, for me ;-) fixes.
- #69: Allow destroy() to be called by user without generating messages
- #66: Remove warning in ofxBox2dBaseShape::setData()
- #65: Polygon create doesn't like 3-sided polygons
- #64: ofxBox2dPolygon::clear() calls itself
