### PR TITLE
Revolute Joint

### DIFF
--- a/libs/triangle/dpoint.hpp
+++ b/libs/triangle/dpoint.hpp
@@ -474,7 +474,7 @@ dpoint<NumType,D>&
 dpoint<NumType,D>::operator=(const dpoint<NumType,D> &q)
 {
 #ifdef _MSC_VER
-	assert((this != &q), "Error p = p");
+	assert(this != &q);
 #else
 	Assert((this != &q), "Error p = p");
 #endif

--- a/src/ofxBox2d.h
+++ b/src/ofxBox2d.h
@@ -10,6 +10,7 @@
 #include "ofxBox2dRect.h"
 
 #include "ofxBox2dJoint.h"
+#include "ofxBox2dRevoluteJoint.h"
 #include "ofxBox2dRender.h"
 #include "ofxBox2dContactListener.h"
 

--- a/src/ofxBox2dPolygonUtils.h
+++ b/src/ofxBox2dPolygonUtils.h
@@ -112,9 +112,10 @@ static vector <ofVec2f> simplifyContour(vector <ofVec2f> &V, float tol) {
     float  tol2 = tol * tol;       // tolerance squared
     
     vector<ofVec2f> vt(n);
-	int mk[n];
+	//int mk[n];
+	vector<int> mk(n, 0);
 	
-	memset(mk, 0, sizeof(mk));
+	//memset(mk, 0, sizeof(mk));
 	
     // STAGE 1.  Vertex Reduction within tolerance of prior vertex cluster
     vt[0] = V[0];              // start at the beginning
@@ -128,7 +129,7 @@ static vector <ofVec2f> simplifyContour(vector <ofVec2f> &V, float tol) {
     // STAGE 2.  Douglas-Peucker polyline simplification
     mk[0] = mk[k-1] = 1;       // mark the first and last vertices
     
-    simplifyDP( tol, &vt[0], 0, k-1, mk );
+    simplifyDP( tol, &vt[0], 0, k-1, &mk[0] );
 	
     // copy marked vertices to the output simplified polyline
     for (i=m=0; i<k; i++) {

--- a/src/ofxBox2dRevoluteJoint.cpp
+++ b/src/ofxBox2dRevoluteJoint.cpp
@@ -1,0 +1,220 @@
+/*
+ *  ofxBox2dRevoluteJoint.cpp
+ *  jointExample
+ *
+ *  Created by Nick Hardeman on 1/19/11.
+ *  Copyright 2011 Nick Hardeman. All rights reserved.
+ *
+ */
+
+#include "ofxBox2dRevoluteJoint.h"
+
+//----------------------------------------
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint() {
+	world = NULL;
+	joint = NULL;
+	alive = false;
+}
+
+//----------------------------------------
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle, float upperAngle, bool bCollideConnected) {
+	ofxBox2dRevoluteJoint();
+	setup(b2world, body1, body2, lowerAngle, upperAngle, bCollideConnected);
+}
+
+//----------------------------------------
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle, float upperAngle, bool bCollideConnected) {
+	ofxBox2dRevoluteJoint();
+	setup(b2world, body1, body2, anchor, lowerAngle, upperAngle, bCollideConnected);
+}
+
+//----------------------------------------
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2RevoluteJointDef jointDef) {
+    ofxBox2dRevoluteJoint();
+    setup(b2world, jointDef);
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle, float upperAngle, bool bCollideConnected) {
+	
+	if(body1 == NULL || body2 == NULL) {
+		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setup : - box2d body is NULL -");
+		return;
+	}
+	
+    b2Vec2 a;//, a2;
+	a = body1->GetWorldCenter();
+	//a2 = body2->GetWorldCenter();
+	
+	setup(b2world, body1, body2, a, lowerAngle, upperAngle, bCollideConnected);
+    
+    alive = true;
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle, float upperAngle, bool bCollideConnected) {
+
+	if(body1 == NULL || body2 == NULL) {
+		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setup : - box2d body is NULL -");
+		return;
+	}
+
+	b2RevoluteJointDef jointDef;
+	jointDef.Initialize(body1, body2, anchor);
+	jointDef.collideConnected	= bCollideConnected;
+	jointDef.lowerAngle	= lowerAngle;
+	jointDef.upperAngle = upperAngle;
+	
+    setup(b2world, jointDef);
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2RevoluteJointDef jointDef) {
+
+    setWorld(b2world);
+    
+    joint = (b2RevoluteJoint*)world->CreateJoint(&jointDef);
+	
+	alive = true;
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setWorld(b2World* w) {
+	if(w == NULL) {
+		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setWorld : - box2d world needed -");	
+		return;
+	}
+	world = w;
+}
+
+//----------------------------------------
+bool ofxBox2dRevoluteJoint::isSetup() {
+	if (world == NULL) {
+		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: world must be set!");
+		return false;
+	}
+	if (joint == NULL) {
+		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setup function must be called!");
+		return false;
+	}
+	return true;
+}
+
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::draw() {
+	if(!alive) return;
+	
+	b2Vec2 p1 = joint->GetAnchorA();
+	b2Vec2 p2 = joint->GetAnchorB();
+	
+	p1 *= OFX_BOX2D_SCALE;
+	p2 *= OFX_BOX2D_SCALE;
+	ofDrawLine(p1.x, p1.y, p2.x, p2.y);
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::destroy() {
+	if (!isSetup()) return;
+	if(joint) {
+		world->DestroyJoint(joint);
+	}
+	joint = NULL;
+	alive = false;
+}
+
+void ofxBox2dRevoluteJoint::setLowerAngle(float lowerAngle)
+{
+    if (joint) joint->SetLimits(lowerAngle, joint->GetUpperLimit());
+    else ofLogError() << "joint is null";
+}
+
+float ofxBox2dRevoluteJoint::getLowerAngle() const
+{
+    if (joint) return joint->GetLowerLimit();
+    else
+    {
+        ofLogError() << "joint is null";
+        return 0.f;
+    }
+}
+
+void ofxBox2dRevoluteJoint::setUpperAngle(float upperAngle)
+{
+    if (joint) joint->SetLimits(joint->GetLowerLimit(), upperAngle);
+    else ofLogError() << "joint is null";
+}
+
+float ofxBox2dRevoluteJoint::getUpperAngle() const
+{
+    if (joint) return joint->GetUpperLimit();
+    else
+    {
+        ofLogError() << "joint is null";
+        return 0.f;
+    }
+}
+
+
+/*
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setLength(float len) {
+	if(joint) {
+		joint->SetLength((float32)b2dNum(len));
+	}
+}
+float ofxBox2dRevoluteJoint::getLength() {
+	if(joint) {
+		return (float)joint->GetLength();
+	}
+	return 0;
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setFrequency(float freq) {
+	if(joint) {
+		joint->SetFrequency((float32)freq);
+	}
+}
+float ofxBox2dRevoluteJoint::getFrequency() {
+	if(joint) {
+		return (float)joint->GetFrequency();
+	}
+	return 0;
+}
+
+//----------------------------------------
+void ofxBox2dRevoluteJoint::setDamping(float ratio) {
+	if(joint) {
+		joint->SetDampingRatio((float32)ratio);
+	}
+}
+float ofxBox2dRevoluteJoint::getDamping() {
+	if(joint) {
+		return (float)joint->GetDampingRatio();
+	}
+	return 0;
+}
+*/
+
+//----------------------------------------
+ofVec2f ofxBox2dRevoluteJoint::getReactionForce(float inv_dt) const {
+	b2Vec2 vec = getReactionForceB2D(inv_dt);
+	return ofVec2f(vec.x, vec.y);
+}
+b2Vec2 ofxBox2dRevoluteJoint::getReactionForceB2D(float inv_dt) const {
+	if(joint) {
+		return joint->GetReactionForce(inv_dt);
+	}
+	return b2Vec2(0, 0);
+}
+float ofxBox2dRevoluteJoint::getReactionTorque(float inv_dt) const {
+	if(joint) {
+		return (float)joint->GetReactionTorque(inv_dt);
+	}
+	return 0;
+}
+
+
+
+

--- a/src/ofxBox2dRevoluteJoint.cpp
+++ b/src/ofxBox2dRevoluteJoint.cpp
@@ -155,6 +155,21 @@ float ofxBox2dRevoluteJoint::getUpperAngle() const
     }
 }
 
+void ofxBox2dRevoluteJoint::setEnableLimit(bool enableLimit)
+{
+    if (joint) joint->EnableLimit(enableLimit);
+    else ofLogError() << "joint is null";
+}
+
+bool ofxBox2dRevoluteJoint::getEnableLimit() const
+{
+    if (joint) return joint->IsLimitEnabled();
+    else
+    {
+        ofLogError() << "joint is null";
+        return false;
+    }
+}
 
 /*
 //----------------------------------------

--- a/src/ofxBox2dRevoluteJoint.cpp
+++ b/src/ofxBox2dRevoluteJoint.cpp
@@ -17,15 +17,15 @@ ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint() {
 }
 
 //----------------------------------------
-ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle, float upperAngle, bool bCollideConnected) {
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, bool enableLimit, float lowerAngle, float upperAngle, bool bCollideConnected) {
 	ofxBox2dRevoluteJoint();
-	setup(b2world, body1, body2, lowerAngle, upperAngle, bCollideConnected);
+	setup(b2world, body1, body2, enableLimit, lowerAngle, upperAngle, bCollideConnected);
 }
 
 //----------------------------------------
-ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle, float upperAngle, bool bCollideConnected) {
+ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, bool enableLimit, float lowerAngle, float upperAngle, bool bCollideConnected) {
 	ofxBox2dRevoluteJoint();
-	setup(b2world, body1, body2, anchor, lowerAngle, upperAngle, bCollideConnected);
+	setup(b2world, body1, body2, anchor, enableLimit, lowerAngle, upperAngle, bCollideConnected);
 }
 
 //----------------------------------------
@@ -35,7 +35,7 @@ ofxBox2dRevoluteJoint::ofxBox2dRevoluteJoint(b2World* b2world, b2RevoluteJointDe
 }
 
 //----------------------------------------
-void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle, float upperAngle, bool bCollideConnected) {
+void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, bool enableLimit, float lowerAngle, float upperAngle, bool bCollideConnected) {
 	
 	if(body1 == NULL || body2 == NULL) {
 		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setup : - box2d body is NULL -");
@@ -44,15 +44,14 @@ void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2
 	
     b2Vec2 a;//, a2;
 	a = body1->GetWorldCenter();
-	//a2 = body2->GetWorldCenter();
 	
-	setup(b2world, body1, body2, a, lowerAngle, upperAngle, bCollideConnected);
+	setup(b2world, body1, body2, a, enableLimit, lowerAngle, upperAngle, bCollideConnected);
     
     alive = true;
 }
 
 //----------------------------------------
-void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle, float upperAngle, bool bCollideConnected) {
+void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, bool enableLimit, float lowerAngle, float upperAngle, bool bCollideConnected) {
 
 	if(body1 == NULL || body2 == NULL) {
 		ofLog(OF_LOG_NOTICE, "ofxBox2dRevoluteJoint :: setup : - box2d body is NULL -");
@@ -64,6 +63,7 @@ void ofxBox2dRevoluteJoint::setup(b2World* b2world, b2Body* body1, b2Body* body2
 	jointDef.collideConnected	= bCollideConnected;
 	jointDef.lowerAngle	= lowerAngle;
 	jointDef.upperAngle = upperAngle;
+    jointDef.enableLimit = enableLimit;
 	
     setup(b2world, jointDef);
 }

--- a/src/ofxBox2dRevoluteJoint.h
+++ b/src/ofxBox2dRevoluteJoint.h
@@ -36,7 +36,10 @@ public:
     
     void setUpperAngle(float upperAngle);
     float getUpperAngle() const;
-	
+    
+    void setEnableLimit(bool enableLimit);
+    bool getEnableLimit() const;
+    
 	//----------------------------------------
 	ofVec2f getReactionForce(float inv_dt) const;
 	b2Vec2  getReactionForceB2D(float inv_dt) const;

--- a/src/ofxBox2dRevoluteJoint.h
+++ b/src/ofxBox2dRevoluteJoint.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "ofMain.h"
+#include "Box2D.h"
+#include "ofxBox2dUtils.h"
+
+#define BOX2D_DEFAULT_FREQ      4.0
+#define BOX2D_DEFAULT_DAMPING   0.5
+
+class ofxBox2dRevoluteJoint {
+	
+public:
+	b2World			*	world;
+	b2RevoluteJoint *	joint;
+	int					jointType;
+	bool				alive;
+	
+	//----------------------------------------
+	ofxBox2dRevoluteJoint();
+	ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+	ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+    ofxBox2dRevoluteJoint(b2World* b2world, b2RevoluteJointDef jointDef);
+	
+	//----------------------------------------
+	void setWorld(b2World * w);
+	void setup(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+	void setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+    void setup(b2World* b2world, b2RevoluteJointDef jointDef);
+	
+	//----------------------------------------
+	bool isSetup();
+	void draw();
+	void destroy();
+    
+    void setLowerAngle(float lowerAngle);
+    float getLowerAngle() const;
+    
+    void setUpperAngle(float upperAngle);
+    float getUpperAngle() const;
+	
+	//----------------------------------------
+	ofVec2f getReactionForce(float inv_dt) const;
+	b2Vec2  getReactionForceB2D(float inv_dt) const;
+	float   getReactionTorque(float inv_dt) const;
+};
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/ofxBox2dRevoluteJoint.h
+++ b/src/ofxBox2dRevoluteJoint.h
@@ -16,14 +16,14 @@ public:
 	
 	//----------------------------------------
 	ofxBox2dRevoluteJoint();
-	ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
-	ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+	ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, bool enableLimit = false, float lowerAngle = -.25f * PI, float upperAngle = .25f * PI, bool bCollideConnected = true);
+    ofxBox2dRevoluteJoint(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, bool enableLimit = false, float lowerAngle = -.25f * PI, float upperAngle = .25f * PI, bool bCollideConnected = true);
     ofxBox2dRevoluteJoint(b2World* b2world, b2RevoluteJointDef jointDef);
 	
 	//----------------------------------------
 	void setWorld(b2World * w);
-	void setup(b2World* b2world, b2Body* body1, b2Body* body2, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
-	void setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, float lowerAngle=-HALF_PI, float upperAngle=HALF_PI, bool bCollideConnected=true);
+	void setup(b2World* b2world, b2Body* body1, b2Body* body2, bool enableLimit = false, float lowerAngle = -.25f * PI, float upperAngle = .25f * PI, bool bCollideConnected = true);
+	void setup(b2World* b2world, b2Body* body1, b2Body* body2, b2Vec2 anchor, bool enableLimit = false, float lowerAngle = -.25f * PI, float upperAngle = .25f * PI, bool bCollideConnected = true);
     void setup(b2World* b2world, b2RevoluteJointDef jointDef);
 	
 	//----------------------------------------


### PR DESCRIPTION
I've added in ofxBox2dRevoluteJoint. I'm guessing from the fact that there's a jointType member in ofxBox2dJoint that you had intended that class to encapsulate all joints but seemed to make more sense as a separate class. Maybe ofxBox2dJoint could be renamed to ofxBox2dDistanceJoint with a typedef of ofxBox2dJoint for backwards compatibility. Also, haven't added an example but could do if you want...