### PR TITLE
Add #include <stdio.h> because using printf causes a compile error

### DIFF
--- a/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
+++ b/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
@@ -21,6 +21,7 @@
 
 #include "Box2D.h"
 #include "b2Triangle.h"
+#include <stdio.h>
 
 class b2Polygon;
 

--- a/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
+++ b/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
@@ -21,7 +21,7 @@
 
 #include "Box2D.h"
 #include "b2Triangle.h"
-#include <stdio.h>
+#include <cstdio>
 
 class b2Polygon;
 


### PR DESCRIPTION
Hello
I get a compile error in my modified file saying 
```terminal
error:‘printf’ was not declared in this scope 
```
#include <stdio.h>
Send a pull request with the addition of.