### PR TITLE
Emscripten compatibility

### DIFF
--- a/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
+++ b/libs/liquidfun/Contributions/Utilities/ConvexDecomposition/b2Polygon.h
@@ -21,6 +21,7 @@
 
 #include "Box2D.h"
 #include "b2Triangle.h"
+#include "cstdio"
 
 class b2Polygon;
 


### PR DESCRIPTION
Adds `#include "cstdio"` to `b2Polygon.h`.